### PR TITLE
Models for 'owner' and 'release owner' ACL files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,9 @@
       "error",
       { "prefixWithI": "always" }
     ],
-    "no-restricted-syntax": 0
+    "@typescript-eslint/no-unused-vars": 0,
+    "no-restricted-syntax": 0,
+    "no-useless-constructor": 0
   },
   "settings": {
     "parser": "typescript-eslint-parser",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src test --ext js,ts",
     "start": "pm2 start ./lib/index.js -i max",
     "pretest": "tsc -b test",
-    "test": "qunit test-js/test/**/*.test.js",
+    "test": "qunit 'test-js/test/**/*.test.js'",
     "test:ci": "yarn test && yarn test:types",
     "test:types": "dtslint type-tests",
     "watch": "concurrently \"npm:watch:build\" \"npm:watch:dev\" \"yarn pm2 log\" -n \"TS,PM,Log\" -c \"bgYellow.black,bgGreen.black,bgWhite.black\"",

--- a/src/models/acl/base.ts
+++ b/src/models/acl/base.ts
@@ -1,0 +1,51 @@
+/**
+ * A base type describing optional properties that may
+ * be found in _any_ ACL
+ *
+ * @private
+ */
+export interface IAclBase {
+  whitelist?: string[];
+  paths: string[];
+  exclude_paths?: string[];
+  description?: string;
+  block_message?: string;
+  groups?: string[];
+}
+
+export default abstract class AclBase implements IAclBase {
+  whitelist?: string[];
+
+  paths: string[] = [];
+
+  exclude_paths?: string[];
+
+  description?: string;
+
+  block_message?: string;
+
+  groups?: string[];
+
+  abstract kind: 'owner' | 'release_owner';
+
+  protected pathRegexes: RegExp[];
+
+  protected constructor(arg: IAclBase) {
+    this.paths = arg.paths;
+    if (arg.paths.length === 0)
+      throw new Error(`Paths invalid: ${JSON.stringify(arg, null, '  ')}`);
+    if (arg.whitelist) this.whitelist = arg.whitelist;
+    if (arg.exclude_paths) this.exclude_paths = arg.exclude_paths;
+    if (arg.description) this.description = arg.description;
+    if (arg.block_message) this.block_message = arg.block_message;
+    if (arg.groups) this.groups = arg.groups;
+    this.pathRegexes = this.paths.map(p => new RegExp(p));
+  }
+
+  appliesToFile(filePath: string): boolean {
+    for (const r of this.pathRegexes) {
+      if (r.test(filePath)) return true;
+    }
+    return false;
+  }
+}

--- a/src/models/acl/owner.ts
+++ b/src/models/acl/owner.ts
@@ -1,0 +1,22 @@
+import AclBase, { IAclBase } from './base';
+
+export interface IOwnerAcl extends IAclBase {
+  owners: string[];
+  paths: string[];
+}
+
+/**
+ * An ACL that describes owners. This must _at least_
+ * contain `owners` and `paths` string arrays
+ *
+ */
+export default class OwnerAcl extends AclBase implements IOwnerAcl {
+  owners: string[];
+
+  readonly kind = 'owner' as const;
+
+  constructor(arg: IOwnerAcl) {
+    super(arg);
+    this.owners = arg.owners;
+  }
+}

--- a/src/models/acl/release-owner.ts
+++ b/src/models/acl/release-owner.ts
@@ -1,0 +1,22 @@
+import AclBase, { IAclBase } from './base';
+
+export interface IReleaseOwnerAcl extends IAclBase {
+  release_owners: string[];
+  paths: string[];
+}
+
+/**
+ * An ACL that describes release_owners. This must _at least_
+ * contain `release_owners` and `paths` string arrays
+ */
+export default class ReleaseOwnerAcl extends AclBase
+  implements IReleaseOwnerAcl {
+  release_owners: string[];
+
+  readonly kind = 'release_owner' as const;
+
+  constructor(arg: IReleaseOwnerAcl) {
+    super(arg);
+    this.release_owners = arg.release_owners;
+  }
+}

--- a/test/models/acl/base.test.ts
+++ b/test/models/acl/base.test.ts
@@ -1,0 +1,30 @@
+import BaseAcl, { IAclBase } from '../../../src/models/acl/base';
+
+class SubAcl extends BaseAcl {
+  kind = 'owner' as const;
+
+  constructor(arg: IAclBase) {
+    super(arg);
+  }
+}
+
+QUnit.module('BaseAcl class', _hooks => {
+  QUnit.test('Instantiation should require at least one path', assert => {
+    assert.throws(() => {
+      // eslint-disable-next-line no-new
+      new SubAcl({ paths: [] });
+    });
+
+    assert.ok(
+      new SubAcl({ paths: ['abc/*'] }),
+      'Able to instantiate an ACL subclass',
+    );
+  });
+
+  QUnit.test('appliesToFile', assert => {
+    const acl = new SubAcl({ paths: ['abc/*', 'def/*'] });
+    assert.ok(acl.appliesToFile('abc/foo.txt'));
+    assert.notOk(acl.appliesToFile('foo.txt'));
+    assert.ok(acl.appliesToFile('def/foo.txt'));
+  });
+});

--- a/test/models/acl/owner.test.ts
+++ b/test/models/acl/owner.test.ts
@@ -1,0 +1,12 @@
+import OwnerAcl from '../../../src/models/acl/owner';
+
+QUnit.module('OwnerAcl class', _hooks => {
+  QUnit.test('Instantiation', assert => {
+    assert.ok(
+      new OwnerAcl({
+        paths: ['abc/*'],
+        owners: [],
+      }),
+    );
+  });
+});

--- a/test/models/acl/release-owner.test.ts
+++ b/test/models/acl/release-owner.test.ts
@@ -1,0 +1,12 @@
+import ReleaseOwnerAcl from '../../../src/models/acl/release-owner';
+
+QUnit.module('ReleaseOwnerAcl class', _hooks => {
+  QUnit.test('Instantiation', assert => {
+    assert.ok(
+      new ReleaseOwnerAcl({
+        release_owners: [],
+        paths: ['abc/*'],
+      }),
+    );
+  });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,5 +7,5 @@
     "declaration": false,
     "baseUrl": "."
   },
-  "include": ["."]
+  "include": ["**/*.ts"]
 }


### PR DESCRIPTION
Usage
```ts
const acl = new OwnerAcl({
   paths: ['docs/*'],
   owners: ['mike-north']
}); 
```