### PR TITLE
Debounce returns a promise - resolves when the debounced fn returns/resolves

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,8 @@
         "QUnit": true
       },
       "rules": {
-        "func-names": 0
+        "func-names": 0,
+        "@typescript-eslint/explicit-function-return-type": 0
       },
       "settings": {
         "import/resolver": {

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,4 +1,5 @@
 import { FArguments } from '../types';
+import Deferred from './deferred';
 
 const defaultDebounceMap = new WeakMap<
   Function,
@@ -15,8 +16,9 @@ export function debounce<F extends (...args: any[]) => void>(
   fn: F,
   timeout: number,
   state: WeakMap<Function, ReturnType<typeof setTimeout>> = defaultDebounceMap,
-): (...args: FArguments<F>) => void {
-  return function debounced(...args: FArguments<F>): void {
+): (...args: FArguments<F>) => Promise<void> {
+  let d: Deferred<void> = new Deferred();
+  return function debounced(...args: FArguments<F>): Promise<void> {
     // check to see if we should continue waiting
     const existingTimeout = state.get(fn);
 
@@ -25,10 +27,19 @@ export function debounce<F extends (...args: any[]) => void>(
       clearTimeout(existingTimeout); // cancel the previously queued function
       // queue the new invocation
     }
-    const newTimeout = setTimeout(() => {
+
+    const newTimeout = setTimeout(async () => {
       state.delete(fn); // clear the cancellation token
-      fn(...args); // ! RUN
+      try {
+        const result = await fn(...args); // ! RUN
+        d.resolve(result);
+      } catch (e) {
+        d.reject(e);
+      } finally {
+        d = new Deferred();
+      }
     }, timeout);
     state.set(fn, newTimeout); // store the new cancellation token
+    return d.promise;
   };
 }

--- a/src/utils/deferred.ts
+++ b/src/utils/deferred.ts
@@ -1,0 +1,22 @@
+export default class Deferred<R> {
+  protected resolveFn!: (value?: R | PromiseLike<R> | undefined) => void;
+
+  protected rejectFn!: (reason?: any) => void;
+
+  promise: Promise<R>;
+
+  constructor() {
+    this.promise = new Promise((res, rej): void => {
+      this.resolveFn = res;
+      this.rejectFn = rej;
+    });
+  }
+
+  resolve(value?: R | PromiseLike<R> | undefined): void {
+    this.resolveFn(value);
+  }
+
+  reject(value?: R | PromiseLike<R> | undefined): void {
+    this.resolveFn(value);
+  }
+}

--- a/test/utils/debounce.test.ts
+++ b/test/utils/debounce.test.ts
@@ -1,6 +1,9 @@
 import { debounce } from '../../src/utils/debounce';
+import { IDict } from '../../src/types';
 
-QUnit.module('debounce tests', async function() {
+const timeout = (n: number) => new Promise(res => setTimeout(res, n));
+
+QUnit.module('debounce tests', function() {
   QUnit.test('immediate repeated invocations are debounced', async assert => {
     const done = assert.async();
     let invocationCount = 0;
@@ -39,4 +42,191 @@ QUnit.module('debounce tests', async function() {
       done();
     }, 50);
   });
+
+  QUnit.test(
+    'promise returned by debounce resolves only once work is actually done',
+    async assert => {
+      const done = assert.async();
+      let startCount = 0;
+      let finishCount = 0;
+      async function foo(): Promise<void> {
+        startCount++;
+        await timeout(100);
+        finishCount++;
+      }
+      const debouncedFn = debounce(foo, 15);
+
+      const p1 = debouncedFn(); // first invocation at 0ms
+      const isResolved: IDict<boolean> = {
+        1: false,
+        2: false,
+        3: false,
+      };
+
+      p1.then(() => {
+        isResolved[1] = true;
+      });
+      setTimeout(() => {
+        const p2 = debouncedFn(); // second invocation at 10ms, should trigger a reset of 15ms wait
+        p2.then(() => {
+          isResolved[2] = true;
+        });
+        setTimeout(() => {
+          const p3 = debouncedFn(); // third invocation at 20ms, should trigger a reset of 15ms wait
+          p3.then(() => {
+            isResolved[3] = true;
+          });
+        }, 10);
+      }, 10);
+
+      /**
+       *
+       * @param delay number of ms to wait before asserting
+       * @param expectations number of "start", "finish" and "resolved" indications we expect
+       */
+      function assertAtTime(
+        delay: number,
+        expectations: {
+          starts: number;
+          finishes: number;
+          resolved: number;
+        },
+      ) {
+        const { starts, finishes, resolved } = expectations;
+        setTimeout(() => {
+          assert.equal(
+            startCount,
+            starts,
+            `${starts} innvocations at ${delay}ms`,
+          );
+          assert.equal(
+            finishCount,
+            finishes,
+            `${finishes} finished innvocations at ${delay}ms`,
+          );
+          // count how many promises have resolved
+          const numResolvedPromises = Object.entries(isResolved).reduce(
+            (trues, [_, item]) => {
+              if (item) return trues + 1;
+              return trues;
+            },
+            0,
+          );
+          assert.equal(
+            numResolvedPromises,
+            resolved,
+            `${resolved} promises have resolved at ${delay}ms`,
+          );
+        }, delay);
+      }
+      // at 5ms we should still be debouncing from the first invocation at 0ms
+      assertAtTime(5, { starts: 0, finishes: 0, resolved: 0 });
+      // at 15ms we should still be debouncing from the second invocation at 10ms
+      assertAtTime(15, { starts: 0, finishes: 0, resolved: 0 });
+      // at 30ms we should still be debouncing from the third invocation at 20ms
+      assertAtTime(30, { starts: 0, finishes: 0, resolved: 0 });
+      // at 50ms we should no longer be debouncing, and should see evidence that our async work has begun (but not finished)
+      assertAtTime(50, { starts: 1, finishes: 0, resolved: 0 });
+      // at 160ms we should see that the work has finished, and the shared promise between all three debounced fn invocations should have resolved
+      assertAtTime(160, { starts: 1, finishes: 1, resolved: 3 });
+
+      // keep this test alive for 0.25s, just to make sure all of the above have a chance to run
+      setTimeout(done, 250);
+    },
+  );
+
+  QUnit.test(
+    'a new "shared promise" is used between adequately-spaced debounced invocations',
+    async assert => {
+      const done = assert.async();
+      let startCount = 0;
+      let finishCount = 0;
+      async function foo(): Promise<void> {
+        startCount++;
+        await timeout(20);
+        finishCount++;
+      }
+      const debouncedFn = debounce(foo, 15);
+
+      const p1 = debouncedFn(); // first invocation at 0ms
+      const isResolved: IDict<boolean> = {
+        1: false,
+        2: false,
+        3: false,
+      };
+
+      p1.then(() => {
+        isResolved[1] = true;
+      });
+      setTimeout(() => {
+        const p2 = debouncedFn(); // second invocation at 10ms, should trigger a reset of 15ms wait
+        p2.then(() => {
+          isResolved[2] = true;
+        });
+        setTimeout(() => {
+          const p3 = debouncedFn(); // third invocation at 20ms, should trigger a reset of 15ms wait
+          p3.then(() => {
+            isResolved[3] = true;
+          });
+        }, 70);
+      }, 10);
+
+      /**
+       *
+       * @param delay number of ms to wait before asserting
+       * @param expectations number of "start", "finish" and "resolved" indications we expect
+       */
+      function assertAtTime(
+        delay: number,
+        expectations: {
+          starts: number;
+          finishes: number;
+          resolved: number;
+        },
+      ) {
+        const { starts, finishes, resolved } = expectations;
+        setTimeout(() => {
+          assert.equal(
+            startCount,
+            starts,
+            `${starts} innvocations at ${delay}ms`,
+          );
+          assert.equal(
+            finishCount,
+            finishes,
+            `${finishes} finished innvocations at ${delay}ms`,
+          );
+          // count how many promises have resolved
+          const numResolvedPromises = Object.entries(isResolved).reduce(
+            (trues, [_, item]) => {
+              if (item) return trues + 1;
+              return trues;
+            },
+            0,
+          );
+          assert.equal(
+            numResolvedPromises,
+            resolved,
+            `${resolved} promises have resolved at ${delay}ms`,
+          );
+        }, delay);
+      }
+      // FIRST ROUND OF DEBOUNCING
+      // at 5ms we should still be debouncing from the first invocation at 0ms
+      assertAtTime(5, { starts: 0, finishes: 0, resolved: 0 });
+      // at 15ms we should still be debouncing from the second invocation at 10ms
+      assertAtTime(15, { starts: 0, finishes: 0, resolved: 0 });
+      // after 45ms the promises from the first two invocations (first debounced, second one went through) should have resolved
+      assertAtTime(50, { starts: 1, finishes: 1, resolved: 2 });
+
+      // SECOND ROUND OF DEBOUNCING
+      // at 103ms we should no longer be debouncing, and should see evidence that our next chunk of async work has begun (but not finished)
+      assertAtTime(103, { starts: 2, finishes: 1, resolved: 2 });
+      // at 130ms we should see that our second call to `foo` has finished, and the third promise resolved
+      assertAtTime(130, { starts: 2, finishes: 2, resolved: 3 });
+
+      // keep this test alive for 0.25s, just to make sure all of the above have a chance to run
+      setTimeout(done, 250);
+    },
+  );
 });

--- a/test/utils/deferred.test.ts
+++ b/test/utils/deferred.test.ts
@@ -1,0 +1,60 @@
+import Deferred from '../../src/utils/deferred';
+
+QUnit.module('Deferred tests', _hooks => {
+  QUnit.test(
+    'Expected properties are available, and have expected types',
+    assert => {
+      const d = new Deferred();
+      assert.ok(d.promise instanceof Promise, 'deferred.promise is a Promise');
+      assert.equal(
+        typeof d.resolve,
+        'function',
+        'deferred.resolve is a function',
+      );
+      assert.equal(
+        typeof d.reject,
+        'function',
+        'deferred.reject is a function',
+      );
+    },
+  );
+
+  QUnit.test(
+    '"rejecting" a deferred, rejects its respective promise',
+    async assert => {
+      const d = new Deferred();
+      let isRejected = false;
+      assert.notOk(
+        isRejected,
+        'Before deferred is resolved, its promise is not rejected',
+      );
+      d.reject();
+      await d.promise.then(() => {
+        isRejected = true;
+      });
+      assert.ok(
+        isRejected,
+        'Before deferred is resolved, its promise is not resolved',
+      );
+    },
+  );
+  QUnit.test(
+    '"rejecting" a deferred, resolves its respective promise',
+    async assert => {
+      const d = new Deferred();
+      let isResolved = false;
+      assert.notOk(
+        isResolved,
+        'Before deferred is resolved, its promise is not resolved',
+      );
+      d.resolve();
+      await d.promise.then(() => {
+        isResolved = true;
+      });
+      assert.ok(
+        isResolved,
+        'Before deferred is resolved, its promise is not resolved',
+      );
+    },
+  );
+});


### PR DESCRIPTION
In order to write maintainable tests with code paths that involve use of `debounce`, I need to know when the "debounced" work is actually done. Rather than relying on a polling-based approach like Ember's test-waiters, I'd rather just be able to chain everything together into async functions.

To support this, `debounce` now returns a promise, which resolves or rejects _only when the underlying function being debounced returns or throws_. If the function being debounced returns a promise, `debounce` will wait for that promise to resolve.

In the end, this allows me to use [probot's testing infrastructure](https://probot.github.io/docs/testing/) to just write 

```ts
    // Receive a webhook event
    await probot.receive({ name: 'issues', payload })
```

and `receive` will return a promise that waits for the entire underlying webhook-handling logic to run